### PR TITLE
Add lead generation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ You need Docker, docker-compose and git setup on your machine. Refer [Docker doc
 -   Username: Administrator
 -   Password: admin
 
+ 
+
 ## Learn and connect
 
 -   [Telegram Public Group](https://t.me/frappecrm)
@@ -193,3 +195,17 @@ You need Docker, docker-compose and git setup on your machine. Refer [Docker doc
 		</picture>
 	</a>
 </div>
+
+## Lead Generation API
+
+Use the `leadgen_api` service to automate voice campaigns.
+Example to upload leads:
+```bash
+curl -X POST http://localhost:8000/leads -H "Content-Type: application/json" -d '[{"name":"John","phone_number":"+15555555555","campaign_id":1}]'
+```
+Create a campaign and start calling:
+```bash
+curl -X POST http://localhost:8000/campaigns -H "Content-Type: application/json" -d '{"title":"Demo","description":"Product demo","call_script":"Hello {name}, check our {context}"}'
+curl -X POST http://localhost:8000/campaigns/1/start
+```
+Set `FRAPPE_SITE` to your CRM site to sync leads and call logs with Frappe.

--- a/leadgen_api/calling.py
+++ b/leadgen_api/calling.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlmodel import Session, select
+from twilio.rest import Client
+
+from .frappe_bridge import log_call as log_call_frappe
+from .frappe_bridge import update_lead_status as update_lead_status_frappe
+from .models import CallLog, Lead
+
+
+class TwilioCaller:
+	def __init__(self, account_sid: str, auth_token: str, from_number: str):
+		self.client = Client(account_sid, auth_token)
+		self.from_number = from_number
+
+	async def place_call(self, lead: Lead, webhook_url: str) -> str | None:
+		"""Place a call via Twilio."""
+		try:
+		    call = self.client.calls.create(
+		        to=lead.phone_number,
+		        from_=self.from_number,
+		        url=webhook_url,
+		    )
+		    return call.sid
+		except Exception:
+		    return None
+
+
+def log_call(
+       session: Session,
+       lead_id: int,
+       status: str,
+       duration: int | None = None,
+       *,
+       call_sid: str | None = None,
+       from_number: str | None = None,
+       to_number: str | None = None,
+) -> None:
+       call_log = CallLog(lead_id=lead_id, status=status, duration=duration)
+       session.add(call_log)
+       session.commit()
+
+       lead = session.exec(select(Lead).where(Lead.id == lead_id)).one()
+       if lead.frappe_name and call_sid and from_number and to_number:
+               log_call_frappe(call_sid, lead.frappe_name, from_number, to_number, status, duration)
+
+
+def update_lead_status(session: Session, lead_id: int, status: str) -> None:
+       lead = session.exec(select(Lead).where(Lead.id == lead_id)).one()
+       lead.status = status
+       session.add(lead)
+       session.commit()
+
+       if lead.frappe_name:
+               update_lead_status_frappe(lead.frappe_name, status)

--- a/leadgen_api/database.py
+++ b/leadgen_api/database.py
@@ -1,0 +1,12 @@
+from sqlmodel import Session, SQLModel, create_engine
+
+engine = create_engine("sqlite:///leadgen.db")
+
+
+def init_db() -> None:
+	SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+	with Session(engine) as session:
+	    yield session

--- a/leadgen_api/frappe_bridge.py
+++ b/leadgen_api/frappe_bridge.py
@@ -1,0 +1,91 @@
+import os
+from contextlib import contextmanager
+
+try:
+    import frappe
+except Exception:  # pragma: no cover - frappe not installed during tests
+    frappe = None
+
+
+@contextmanager
+def frappe_context():
+    """Connect to a Frappe site if configured."""
+    if not frappe:
+        yield False
+        return
+
+    site = os.environ.get("FRAPPE_SITE")
+    if not site:
+        yield False
+        return
+
+    frappe.init(site=site)
+    frappe.connect()
+    try:
+        yield True
+    finally:
+        frappe.destroy()
+
+
+def create_lead(name: str, phone_number: str, context: str | None = None) -> str | None:
+    """Create a CRM Lead in Frappe and return its name."""
+    with frappe_context() as active:
+        if not active:
+            return None
+
+        doc = frappe.get_doc({
+            "doctype": "CRM Lead",
+            "lead_name": name,
+            "mobile_no": phone_number,
+            "source": context or "Leadgen",
+        })
+        doc.insert(ignore_permissions=True)
+        frappe.db.commit()
+        return doc.name
+
+
+def log_call(
+    call_sid: str,
+    lead_name: str,
+    from_number: str,
+    to_number: str,
+    status: str,
+    duration: int | None = None,
+) -> None:
+    """Create or update a CRM Call Log in Frappe."""
+    with frappe_context() as active:
+        if not active:
+            return
+
+        if frappe.db.exists("CRM Call Log", call_sid):
+            frappe.db.set_value("CRM Call Log", call_sid, "status", status)
+            if duration is not None:
+                frappe.db.set_value("CRM Call Log", call_sid, "duration", duration)
+            frappe.db.commit()
+            return
+
+        doc = frappe.get_doc({
+            "doctype": "CRM Call Log",
+            "name": call_sid,
+            "id": call_sid,
+            "from": from_number,
+            "to": to_number,
+            "type": "Outgoing",
+            "status": status,
+            "telephony_medium": "Twilio",
+            "reference_doctype": "CRM Lead",
+            "reference_docname": lead_name,
+        })
+        doc.insert(ignore_permissions=True)
+        frappe.db.commit()
+
+
+def update_lead_status(lead_name: str, status: str) -> None:
+    """Update the status of a CRM Lead."""
+    with frappe_context() as active:
+        if not active:
+            return
+
+        if frappe.db.exists("CRM Lead", lead_name):
+            frappe.db.set_value("CRM Lead", lead_name, "status", status)
+            frappe.db.commit()

--- a/leadgen_api/main.py
+++ b/leadgen_api/main.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException, Response
+from fastapi.responses import RedirectResponse
+from sqlmodel import Session, select
+
+from .calling import TwilioCaller, log_call, update_lead_status
+from .database import get_session, init_db
+from .frappe_bridge import create_lead
+from .models import Campaign, Lead
+
+app = FastAPI(title="AI Lead Generation")
+
+init_db()
+
+twilio_caller: TwilioCaller | None = None
+SessionDep = Depends(get_session)
+
+
+@app.post("/setup_twilio")
+async def setup_twilio(account_sid: str, auth_token: str, from_number: str):
+	global twilio_caller
+	twilio_caller = TwilioCaller(account_sid, auth_token, from_number)
+	return {"status": "configured"}
+
+
+@app.post("/leads")
+async def upload_leads(leads: list[Lead], session: Session = SessionDep):
+       for lead in leads:
+           lead.frappe_name = create_lead(lead.name, lead.phone_number, lead.context)
+           session.add(lead)
+       session.commit()
+       return {"added": len(leads)}
+
+
+@app.post("/campaigns")
+async def create_campaign(campaign: Campaign, session: Session = SessionDep):
+	session.add(campaign)
+	session.commit()
+	session.refresh(campaign)
+	return campaign
+
+
+@app.post("/campaigns/{campaign_id}/start")
+async def start_campaign(campaign_id: int, background: BackgroundTasks, session: Session = SessionDep):
+	campaign = session.exec(select(Campaign).where(Campaign.id == campaign_id)).one_or_none()
+	if not campaign:
+	    raise HTTPException(status_code=404, detail="Campaign not found")
+	leads = session.exec(select(Lead).where(Lead.campaign_id == campaign_id)).all()
+	for lead in leads:
+	    background.add_task(place_call_task, lead.id, campaign_id)
+	return {"started": len(leads)}
+
+
+async def place_call_task(lead_id: int, campaign_id: int):
+       if not twilio_caller:
+           return
+       with next(get_session()) as session:
+           lead = session.exec(select(Lead).where(Lead.id == lead_id)).one()
+           webhook_url = f"/voice/intro?lead_id={lead.id}&campaign_id={campaign_id}"
+           call_sid = await twilio_caller.place_call(lead, webhook_url)
+           if not call_sid:
+                log_call(session, lead.id, "call_failed")
+                update_lead_status(session, lead.id, "failed")
+           else:
+                log_call(
+                    session,
+                    lead.id,
+                    "Initiated",
+                    call_sid=call_sid,
+                    from_number=twilio_caller.from_number,
+                    to_number=lead.phone_number,
+                )
+
+
+@app.post("/voice/intro")
+async def voice_intro(lead_id: int, campaign_id: int, session: Session = SessionDep):
+	campaign = session.exec(select(Campaign).where(Campaign.id == campaign_id)).one()
+	lead = session.exec(select(Lead).where(Lead.id == lead_id)).one()
+	say_text = campaign.call_script.format(name=lead.name, context=lead.context or "")
+	twiml = f"""<Response><Gather action='/voice/handle?lead_id={lead.id}' numDigits='1'><Say>{say_text}</Say></Gather><Say>No input received. Goodbye!</Say></Response>"""
+	return Response(content=twiml, media_type="text/xml")
+
+
+@app.post("/voice/handle")
+async def voice_handle(lead_id: int, digits: str = "", session: Session = SessionDep):
+       if digits == "1":
+           update_lead_status(session, lead_id, "Qualified")
+           log_call(session, lead_id, "Completed")
+           return RedirectResponse(url="/voice/transfer")
+       elif digits == "2":
+           update_lead_status(session, lead_id, "Unqualified")
+           log_call(session, lead_id, "Completed")
+           return "<Response><Say>Thank you. Goodbye!</Say></Response>"
+       else:
+           update_lead_status(session, lead_id, "Contacted")
+           log_call(session, lead_id, "No Answer")
+           return "<Response><Say>No input received. Goodbye!</Say></Response>"

--- a/leadgen_api/models.py
+++ b/leadgen_api/models.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class Lead(SQLModel, table=True):
+       id: int | None = Field(default=None, primary_key=True)
+       name: str
+       phone_number: str
+       context: str | None = None
+       status: str = "pending"  # pending, interested, not_interested, failed, no_answer
+       campaign_id: int | None = Field(default=None, foreign_key="campaign.id")
+       frappe_name: str | None = None
+
+class Campaign(SQLModel, table=True):
+	id: int | None = Field(default=None, primary_key=True)
+	title: str
+	description: str
+	call_script: str
+	created_at: datetime = Field(default_factory=datetime.utcnow)
+
+class CallLog(SQLModel, table=True):
+	id: int | None = Field(default=None, primary_key=True)
+	lead_id: int = Field(foreign_key="lead.id")
+	status: str
+	duration: int | None = None
+	updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,11 @@ requires-python = ">=3.10"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
-    # "frappe~=15.0.0" # Installed and managed by bench.
-    "twilio==8.5.0"
+	# "frappe~=15.0.0" # Installed and managed by bench.
+	"twilio==8.5.0",
+	"fastapi==0.110.0",
+	"uvicorn==0.23.2",
+	"sqlmodel==0.0.12",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- add FastAPI-based lead generation service
- integrate simple Twilio caller
- document how to use the new API
- sync leads & call logs with Frappe

## Testing
- `ruff check leadgen_api --fix`


------
https://chatgpt.com/codex/tasks/task_e_6841afefc94c8330acbecee9c261f03a